### PR TITLE
Timestamped model 추가

### DIFF
--- a/medium_clone/medium_clone/common/models.py
+++ b/medium_clone/medium_clone/common/models.py
@@ -1,0 +1,11 @@
+from django.db import models
+
+
+class Timestamped(models.Model):
+    # Automatically set the field to now every time the object is saved.
+    created_at = models.DateTimeField(auto_now_add=True)
+    # Automatically set the field to now when the object is first created.
+    modified_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True


### PR DESCRIPTION
# 목적
- 매번 model에서 `created_at`과 `modified_at`을 지정하지 않도록 한다. 

# 설명
- abstract class인 `Timestamped` model을 추가했다.
- 다른 model에서 상속 받아 사용한다.

# 참고
- https://docs.djangoproject.com/en/3.2/topics/db/models/#abstract-base-classes