### PR TITLE
feature: Use path instead of url

### DIFF
--- a/medium_clone/apps/authentication/urls.py
+++ b/medium_clone/apps/authentication/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import include, url
+from django.urls import path
 from rest_framework.authtoken.views import obtain_auth_token
 
 from .views import RegisterView
 
 urlpatterns = [
-    url(r"^register/", RegisterView.as_view(), name="register"),
-    url(r"^get-auth-token/", obtain_auth_token, name="get-auth-token")
+    path("register/", RegisterView.as_view(), name="register"),
+    path("get-auth-token/", obtain_auth_token, name="get-auth-token")
 ]

--- a/medium_clone/apps/urls.py
+++ b/medium_clone/apps/urls.py
@@ -1,5 +1,6 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import path
 
 urlpatterns = [
-    url(r"^api/", include("apps.authentication.urls"))
+    path("api/", include("apps.authentication.urls"))
 ]


### PR DESCRIPTION
# 목적
- 장고가 이전에 사용하던 url 매칭 방식을 더는 사용하지 않습니다.

# 변경 사항
- `urls.py`에서 `url`을 사용하던 부분을 `path`로 바꿈.
- `path`에서 정규 표현식을 사용하지 않음.

# 참고
- https://blog.naver.com/PostView.nhn?blogId=emmaeunji&logNo=221737920089&parentCategoryNo=&categoryNo=17&viewDate=&isShowPopularPosts=true&from=search
- https://docs.djangoproject.com/en/3.2/topics/http/urls/#example
- 정규 표현식을 쓰고 싶다면 `re_path`를 사용한다. https://docs.djangoproject.com/en/3.2/topics/http/urls/#using-regular-expressions