### PR TITLE
feature: Create profile in register serializer create method

### DIFF
--- a/medium_clone/apps/authentication/serializers.py
+++ b/medium_clone/apps/authentication/serializers.py
@@ -46,7 +46,6 @@ class RegisterSerializer(serializers.ModelSerializer):
         # hashed password
         user.set_password(validated_data["password"])
         user.save()
-        raise AssertionError()
 
         Profile.objects.create(user=user)
 

--- a/medium_clone/apps/authentication/serializers.py
+++ b/medium_clone/apps/authentication/serializers.py
@@ -1,9 +1,12 @@
 from typing import Any, Mapping, Type
 
+from django.db import transaction
 from django.contrib.auth.models import User
 from django.contrib.auth.password_validation import validate_password
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
+
+from apps.profiles.models import Profile
 
 
 class RegisterSerializer(serializers.ModelSerializer):
@@ -29,7 +32,11 @@ class RegisterSerializer(serializers.ModelSerializer):
 
         return attrs
 
+    @transaction.atomic
     def create(self, validated_data: Mapping[str, Any]) -> Type[User]:
+        # TODO: Don't use set_password.
+        # create_user already makes password hashed using make_password
+        # Just pass validate password to create_user
         user = User.objects.create_user(
             username=validated_data["username"],
             email=validated_data["email"],
@@ -39,5 +46,8 @@ class RegisterSerializer(serializers.ModelSerializer):
         # hashed password
         user.set_password(validated_data["password"])
         user.save()
+        raise AssertionError()
+
+        Profile.objects.create(user=user)
 
         return user


### PR DESCRIPTION
# 목적
- `User`가 생성될 때 `Profile`도 같이 생성해 별도로 `Profile`을 생성하지 않도록 합니다.

# 변경 사항
- `authentication/serializers.py`
  - `create` 메서드에서 해당 `User`의 `Profile`을 생성한다.
  - `@transaction.atomic` 데코레이터를 이용해 유저만 생성되고 프로필은 생성되지 않는 경우를 막는다.

# 참고
- 트랜잭션
  - https://docs.djangoproject.com/ko/3.2/topics/db/transactions/
  - https://blog.live2skull.kr/django/django-orm-02-transaction/