### PR TITLE
hotfix: Convert TIME_ZONE from UTC to Asia/Seoul

### DIFF
--- a/medium_clone/apps/settings.py
+++ b/medium_clone/apps/settings.py
@@ -116,7 +116,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Seoul'
 
 USE_I18N = True
 


### PR DESCRIPTION
## 목적
- API에서 날짜 필드를 제공할 때 UTC가 아닌 Asia/Seoul로 제공합니다.