### PR TITLE
feature: Add post retrieve api

### DIFF
--- a/medium_clone/apps/posts/serializers.py
+++ b/medium_clone/apps/posts/serializers.py
@@ -15,14 +15,17 @@ class PostSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Post
-        fields = ("author", "title", "slug", "body", "description")
+        fields = ("author", "title", "slug", "body",
+                  "description", "created_at", "modified_at")
         extra_kwargs = {
             "title": {"required": True},
             # slug is made of title.
             "slug": {"read_only": True},
             "body": {"required": True},
             # description is given or made of body.
-            "description": {"required": False}
+            "description": {"required": False},
+            "created_at": {"read_only": True},
+            "modified_at": {"read_only": True}
         }
 
     def create(self, validated_data):

--- a/medium_clone/apps/posts/views.py
+++ b/medium_clone/apps/posts/views.py
@@ -1,4 +1,5 @@
-from rest_framework import viewsets, status
+from rest_framework import status, viewsets
+from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
 from apps.common.permissions import IsOwnerOrReadOnly
@@ -8,8 +9,10 @@ from .serializers import PostSerializer
 
 
 class PostViewSet(viewsets.ViewSet):
-    # TODO: Add `slug` field as lookup.
+    # A lookup field except for pk has to be defined because router doesn't specify each url.
+    lookup_field = "slug"
     permission_classes = (IsOwnerOrReadOnly, )
+    # author is Profile model, so it requires User model for user info.
     queryset = Post.objects.select_related("author", "author__user")
     serializer_class = PostSerializer
 
@@ -20,3 +23,13 @@ class PostViewSet(viewsets.ViewSet):
         serializer.save()
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def retrieve(self, request, slug):
+        try:
+            instance = self.queryset.get(slug=slug)
+        except Post.DoesNotExist:
+            raise NotFound(f"slug `{slug}` doesn't exist.")
+
+        serializer = self.serializer_class(instance=instance)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## 목적
- 이미 존재하는 slug를 넘겨줬을 때 해당 post를 반환하는 retrieve API를 제공합니다.

## 변경사항
- `PostViewSet`에 `retrieve` 추가
- `PostViewSetTests` 추가
- `PostSerializer`의 serialization field로 `created_at`, `modified_at` 추가