### PR TITLE
hotfix: Handle no account user create post

### DIFF
--- a/medium_clone/apps/posts/exceptions.py
+++ b/medium_clone/apps/posts/exceptions.py
@@ -1,0 +1,7 @@
+from rest_framework.exceptions import APIException
+
+
+class UserNoAccount(APIException):
+    status_code = 400
+    default_detail = "User doesn't have a account."
+    default_code = "user_no_account"

--- a/medium_clone/apps/posts/tests.py
+++ b/medium_clone/apps/posts/tests.py
@@ -86,6 +86,14 @@ class PostViewSetTests(APITestCase):
         response = client.post(reverse("post-list"), data, format="json")
         cls.user1_slug = response.data["slug"]
 
+    def test_no_account_user_create_post(self):
+        """
+        User which doesn't have a account can't create a post.
+        """
+        self.client.credentials()
+        res = self.client.post(reverse("post-list"))
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_retrieve_allowany(self):
         """
         Anyone can retireve other post even anonymous user.

--- a/medium_clone/apps/posts/views.py
+++ b/medium_clone/apps/posts/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from apps.common.permissions import IsOwnerOrReadOnly
 
+from .exceptions import UserNoAccount
 from .models import Post
 from .pages import DefaultPagination
 from .serializers import PostSerializer
@@ -32,8 +33,16 @@ class PostViewSet(viewsets.ViewSet):
         return queryset
 
     def create(self, request):
+        # Anonymous user can't create a post.
+        try:
+            request.user.profile
+        # TODO: Add test case.
+        except AttributeError:
+            raise UserNoAccount()
+
         serializer = self.serializer_class(data=request.data, context={
-                                           "author": request.user.profile})
+            "author": request.user.profile})
+
         serializer.is_valid(raise_exception=True)
         serializer.save()
 


### PR DESCRIPTION
## 목적
- 계정이 없는 유저가 포스트를 만드는 요청을 실패하도록 만듭니다.

## 변경 사항
- `UserNoAccount` exception 추가
-  `PostViewSet`의 `create`에서 핸들
- 테스트 케이스 추가