### PR TITLE
feature: Add delete api

### DIFF
--- a/medium_clone/apps/posts/tests.py
+++ b/medium_clone/apps/posts/tests.py
@@ -168,3 +168,13 @@ class PostViewSetTests(APITestCase):
         res = self.client.patch(
             reverse("post-detail", kwargs={"slug": self.user1_slug2}), data)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_destroy_post_author_only(self):
+        """
+        Allow author only to destroy his/her post.
+        """
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.user2_token}")
+        res = self.client.delete(
+            reverse("post-detail", kwargs={"slug": self.user1_slug2}))
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)

--- a/medium_clone/apps/posts/views.py
+++ b/medium_clone/apps/posts/views.py
@@ -73,7 +73,6 @@ class PostViewSet(viewsets.ViewSet):
         except Post.DoesNotExist:
             raise NotFound(f"slug `{slug}` doesn't exist.")
 
-        # TODO: Test permission
         self.check_object_permissions(request, instance.author)
 
         serializer = self.serializer_class(

--- a/medium_clone/apps/posts/views.py
+++ b/medium_clone/apps/posts/views.py
@@ -82,3 +82,15 @@ class PostViewSet(viewsets.ViewSet):
         serializer.save()
 
         return Response(serializer.validated_data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, slug):
+        try:
+            instance = self.queryset.get(slug=slug)
+        except Post.DoesNotExist:
+            raise NotFound(f"slug `{slug}` doesn't exist.")
+
+        self.check_object_permissions(request, instance.author)
+
+        instance.delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## 목적
- post를 삭제할 수 있습니다.

## 변경 사항
- `PostViewSet`에 `destroy` 추가
- 테스트 추가
  - 자신의 post만 삭제할 수 있는지