### PR TITLE
feature: Add jwt

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     depends_on:
       - gunicorn
   gunicorn:
+    env_file:
+      - .env
     image: django3:medium_clone
     build:
       context: ..

--- a/medium_clone/apps/authentication/tests.py
+++ b/medium_clone/apps/authentication/tests.py
@@ -17,10 +17,6 @@ class AuthTests(APITestCase):
         }
         client.post(reverse("register"), cls.data, format="json")
 
-    def setUp(self):
-        # Make Email different for every method.
-        self.data["Email"] = f"{self._testMethodName}@test.com"
-
     def test_not_same_email(self):
         """
         Users never have same email.

--- a/medium_clone/apps/authentication/tests.py
+++ b/medium_clone/apps/authentication/tests.py
@@ -3,17 +3,20 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 
-class RegistrationTests(APITestCase):
+class AuthTests(APITestCase):
     @classmethod
     def setUpTestData(cls):
+        client = cls.client_class()
         cls.data = {
             "username": "test",
-            "password": "test1234",
-            "password2": "test1234",
+            "password": "test4321",
+            "password2": "test4321",
+            "email": "test@test.com",
             "first_name": "test",
             "last_name": "test"
         }
         cls.url = reverse("register")
+        client.post(reverse("register"), cls.data, format="json")
 
     def setUp(self):
         # Make Email different for every method.

--- a/medium_clone/apps/authentication/tests.py
+++ b/medium_clone/apps/authentication/tests.py
@@ -15,7 +15,6 @@ class AuthTests(APITestCase):
             "first_name": "test",
             "last_name": "test"
         }
-        cls.url = reverse("register")
         client.post(reverse("register"), cls.data, format="json")
 
     def setUp(self):
@@ -26,15 +25,15 @@ class AuthTests(APITestCase):
         """
         Users never have same email.
         """
-        _ = self.client.post(self.url, self.data, format="json")
-        res = self.client.post(self.url, self.data, format="json")
+        _ = self.client.post(reverse("register"), self.data, format="json")
+        res = self.client.post(reverse("register"), self.data, format="json")
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_password_hashed(self):
         """
         User's password must be hashed.
         """
-        res = self.client.post(self.url, self.data, format="json")
+        res = self.client.post(reverse("register"), self.data, format="json")
         # TODO: user 정보 얻어오는 api가 개발되면 password 가져와서 비교하기
 
     def test_jwt(self):

--- a/medium_clone/apps/authentication/tests.py
+++ b/medium_clone/apps/authentication/tests.py
@@ -36,3 +36,13 @@ class AuthTests(APITestCase):
         """
         res = self.client.post(self.url, self.data, format="json")
         # TODO: user 정보 얻어오는 api가 개발되면 password 가져와서 비교하기
+
+    def test_jwt(self):
+        """
+        Test whether jwt works well or not.
+        """
+        res = self.client.post(reverse("token_obtain_pair"), data={
+            "username": self.data["username"], "password": self.data["password"]}, format="json")
+        res = self.client.post(reverse("token_refresh"), data={
+                               "refresh": res.json()["refresh"]}, format="json")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)

--- a/medium_clone/apps/authentication/tests.py
+++ b/medium_clone/apps/authentication/tests.py
@@ -25,7 +25,7 @@ class AuthTests(APITestCase):
         """
         Users never have same email.
         """
-        _ = self.client.post(reverse("register"), self.data, format="json")
+        self.data["username"] = self._testMethodName
         res = self.client.post(reverse("register"), self.data, format="json")
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/medium_clone/apps/authentication/urls.py
+++ b/medium_clone/apps/authentication/urls.py
@@ -1,12 +1,10 @@
 from django.urls import path
-from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from .views import RegisterView
 
 urlpatterns = [
     path("register/", RegisterView.as_view(), name="register"),
-    path("get-auth-token/", obtain_auth_token, name="get-auth-token"),
     path("jwt/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("jwt/refresh/", TokenRefreshView.as_view(), name="token_refresh")
 ]

--- a/medium_clone/apps/authentication/urls.py
+++ b/medium_clone/apps/authentication/urls.py
@@ -1,9 +1,12 @@
 from django.urls import path
 from rest_framework.authtoken.views import obtain_auth_token
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from .views import RegisterView
 
 urlpatterns = [
     path("register/", RegisterView.as_view(), name="register"),
-    path("get-auth-token/", obtain_auth_token, name="get-auth-token")
+    path("get-auth-token/", obtain_auth_token, name="get-auth-token"),
+    path("jwt/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("jwt/refresh/", TokenRefreshView.as_view(), name="token_refresh")
 ]

--- a/medium_clone/apps/profiles/tests.py
+++ b/medium_clone/apps/profiles/tests.py
@@ -26,9 +26,7 @@ class ProfileRetrieveUpdateTests(APITestCase):
         data["email"] = "test2@test.com"
         client.post(reverse("register"), data, format="json")
 
-        client.post(reverse("get-auth-token"),
-                    {"username": "test1", "password": "test4321"})
-        cls.user1_token = User.objects.get(username="test1").auth_token
+        cls.user1 = User.objects.get(username="test1")
 
     def test_retrieve_allowany(self):
         """
@@ -42,7 +40,7 @@ class ProfileRetrieveUpdateTests(APITestCase):
         """
         Allow owner only to update his/her profile.
         """
-        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.user1_token}")
+        self.client.force_authenticate(user=self.user1)
         res = self.client.patch(
             reverse("profile_retrieveupdate_view", kwargs={"username": "test2"}))
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
@@ -53,8 +51,7 @@ class ProfileRetrieveUpdateTests(APITestCase):
         """
         data = {"bio": "awesome", "username": "test1",
                 "email": "email@test.com"}
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.user1_token}")
+        self.client.force_authenticate(user=self.user1)
         res = self.client.patch(
             reverse("profile_retrieveupdate_view", kwargs={"username": "test1"}), data, format="json")
         self.assertEqual(res.status_code, status.HTTP_200_OK)
@@ -64,10 +61,8 @@ class ProfileRetrieveUpdateTests(APITestCase):
         Client can't use put method.
         """
         data = {"bio": "awesome", "username": "test1",
-        "email": "email@test.com"}
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.user1_token}")
+                "email": "email@test.com"}
+        self.client.force_authenticate(user=self.user1)
         res = self.client.put(
             reverse("profile_retrieveupdate_view", kwargs={"username": "test1"}), data, format="json")
-        self.assertEqual(res.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)       
- 
+        self.assertEqual(res.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/medium_clone/apps/settings.py
+++ b/medium_clone/apps/settings.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'rest_framework.authtoken',
     'apps.profiles',
     'apps.authentication',
     'apps.posts'
@@ -49,7 +48,6 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework.authentication.TokenAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication'
     ],
 }

--- a/medium_clone/apps/settings.py
+++ b/medium_clone/apps/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from pathlib import Path
 from datetime import timedelta
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -21,7 +22,7 @@ ROOT_DIR = BASE_DIR.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'pyso820rtds9b774ibt81u7i3m55vzj1$sb*^d)%3izymcs6m$'
+SECRET_KEY = os.environ["SECRET_KEY"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/medium_clone/apps/settings.py
+++ b/medium_clone/apps/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 from pathlib import Path
+from datetime import timedelta
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -50,6 +51,11 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication'
     ],
+}
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=1)
 }
 
 MIDDLEWARE = [

--- a/medium_clone/apps/settings.py
+++ b/medium_clone/apps/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.TokenAuthentication',
+        'rest_framework_simplejwt.authentication.JWTAuthentication'
     ],
 }
 

--- a/medium_clone/manage.py
+++ b/medium_clone/manage.py
@@ -6,6 +6,9 @@ import sys
 
 def main():
     """Run administrative tasks."""
+    if 'SECRET_KEY' not in os.environ:
+        set_secret_key()
+
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'apps.settings')
     try:
         from django.core.management import execute_from_command_line
@@ -16,6 +19,16 @@ def main():
             "forget to activate a virtual environment?"
         ) from exc
     execute_from_command_line(sys.argv)
+
+
+def set_secret_key():
+    env_file_path = '../docker/.env'
+    if os.path.isfile(env_file_path):
+        with open(env_file_path) as f:
+            for line in f:
+                key, value = line.split('=')
+                if key == 'SECRET_KEY':
+                    os.environ['SECRET_KEY'] = value.strip()
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==3.1.13
 djangorestframework==3.12.0
 gunicorn==20.1.0
+djangorestframework-simplejwt==4.8.0
 ipython


### PR DESCRIPTION
## 목적
- jwt를 이용해 authorization을 합니다.
- authorization을 위해 별도의 DB를 사용하지 않습니다.
- authorization을 위한 토큰에 expiration을 걸 수 있도록 합니다.

## 변경 사항
- jwt 발급 및 리프레쉬 url 추가 
- jwt 테스트 코드 추가
- 테스트 코드에서 token 이용하던 부분 force_authentication 하도록 수정
- 기존의 영구적인 token을 발급하는 url 제거
- 하드 코딩돼있던 `SECRET_KEY`를 `docker/.env`에서 읽도록 수정

## 참고
- https://meetup.toast.com/posts/239
- https://velog.io/@zz3n/HTTP-%EC%9D%B8%EC%A6%9D-JWT
- https://www.pingidentity.com/en/company/blog/posts/2019/jwt-security-nobody-talks-about.html